### PR TITLE
fix: avoid external font download

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,7 @@
 import './globals.css';
-import { Inter } from 'next/font/google';
 import { ReactNode } from 'react';
 import Providers from './providers';
 import { AuthProvider } from '@/context/auth-context';
-
-const inter = Inter({ subsets: ['latin', 'cyrillic'] });
 
 export const metadata = {
   title: 'NAVYK - Платформа для развития навыков и карьеры',
@@ -22,7 +19,7 @@ export default function RootLayout({
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
-      <body className={`${inter.className} antialiased min-h-screen flex flex-col`}>
+      <body className="antialiased min-h-screen flex flex-col">
         <Providers>
           <AuthProvider>
             {children}


### PR DESCRIPTION
## Summary
- remove google font to allow offline builds

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896d8765434832d866df55586a0177f